### PR TITLE
build(deps): upgrade to alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.8_10-alpine
-
-# symlink JVM
-RUN mkdir -p /usr/lib/jvm/default-jvm /usr/java/latest \
-    && ln -sf /opt/java/openjdk /usr/lib/jvm/default-jvm/jre \
-    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
+FROM alpine:3.13
 
 # ===============
 # Alpine packages
 # ===============
 
 RUN apk update \
-    && apk add --no-cache openssl py3-pip tini bash \
-    && apk add --no-cache --virtual build-deps wget git gcc musl-dev python3-dev libffi-dev openssl-dev libxml2-dev libxslt-dev
+    && apk add --no-cache openssl py3-pip tini bash openjdk11-jre-headless \
+    && apk add --no-cache --virtual build-deps wget git gcc musl-dev python3-dev libffi-dev openssl-dev libxml2-dev libxslt-dev cargo \
+    && mkdir -p /usr/java/latest \
+    && ln -sf /usr/lib/jvm/default-jvm/jre /usr/java/latest/jre
 
 # =====
 # Jetty


### PR DESCRIPTION
Overview:

- upgrade OS to Alpine v3.13
- handle error when building `cryptography` v3.4.x  library